### PR TITLE
Added require package python-cql to dsc package in install.pp

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,6 @@
 class cassandra::install {
     package { 'dsc':
+        require => Package['python-cql'],
         ensure => $cassandra::version,
         name   => $cassandra::package_name,
     }


### PR DESCRIPTION
Added require line to produce correct order, otherwise (for me at least) apt-get install dsc1.1 would fail due to missing the dependency python-cql
