### PR TITLE
RedHat support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,7 +48,7 @@ class cassandra::config(
     }
 
     file { $data_file_directories:
-        ensure  => directory,    
+        ensure  => directory,
     }
 
     file { "${config_path}/cassandra-env.sh":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,8 +41,8 @@ class cassandra::config(
     }
 
     File {
-        owner   => 'root',
-        group   => 'root',
+        owner   => 'cassandra',
+        group   => 'cassandra',
         mode    => '0644',
         require => Class['cassandra::install'],
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,6 +47,10 @@ class cassandra::config(
         require => Class['cassandra::install'],
     }
 
+    file { $data_file_directories:
+        ensure  => directory,    
+    }
+
     file { "${config_path}/cassandra-env.sh":
         ensure  => file,
         content => template("${module_name}/cassandra-env.sh.erb"),

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,5 @@
 class cassandra::config(
+    $config_path,
     $max_heap_size,
     $heap_newsize,
     $jmx_port,
@@ -46,12 +47,12 @@ class cassandra::config(
         require => Class['cassandra::install'],
     }
 
-    file { '/etc/cassandra/cassandra-env.sh':
+    file { "${config_path}/cassandra-env.sh":
         ensure  => file,
         content => template("${module_name}/cassandra-env.sh.erb"),
     }
 
-    file { '/etc/cassandra/cassandra.yaml':
+    file { "${config_path}/cassandra.yaml":
         ensure  => file,
         content => template("${module_name}/cassandra.yaml.erb"),
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,7 @@ class cassandra(
     $package_name               = $cassandra::params::package_name,
     $version                    = $cassandra::params::version,
     $service_name               = $cassandra::params::service_name,
+    $config_path                = $cassandra::params::config_path,
     $include_repo               = $cassandra::params::include_repo,
     $repo_name                  = $cassandra::params::repo_name,
     $repo_baseurl               = $cassandra::params::repo_baseurl,
@@ -125,6 +126,7 @@ class cassandra(
     include cassandra::install
 
     class { 'cassandra::config':
+        config_path                => $config_path,
         max_heap_size              => $max_heap_size,
         heap_newsize               => $heap_newsize,
         jmx_port                   => $jmx_port,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,13 @@ class cassandra::install {
         name   => $cassandra::package_name,
     }
 
-    package { 'python-cql':
+    $python_cql_name = $::osfamily ? {
+        'Debian'    => 'python-cql',
+        'RedHat'    => 'python26-cql',
+        default     => 'python-cql',
+    }
+
+    package { $python_cql_name:
         ensure => installed,
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,6 +64,18 @@ class cassandra::params {
                 default => $::cassandra_service_name,
             }
         }
+        'RedHat': {
+            $package_name = $::cassandra_package_name ? {
+                undef   => 'dsc12',
+                default => $::cassandra_package_name,
+            }
+
+            $service_name = $::cassandra_service_name ? {
+                undef   => 'cassandra',
+                default => $::cassandra_service_name,
+            }
+
+        }
         default: {
             fail("Unsupported osfamily: ${::osfamily}, operatingsystem: ${::operatingsystem}, module ${module_name} only supports osfamily Debian")
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,6 +63,11 @@ class cassandra::params {
                 undef   => 'cassandra',
                 default => $::cassandra_service_name,
             }
+
+            $config_path = $::cassandra_config_path ? {
+                undef   => '/etc/cassandra',
+                default => $::cassandra_config_path,
+            }
         }
         'RedHat': {
             $package_name = $::cassandra_package_name ? {
@@ -75,6 +80,10 @@ class cassandra::params {
                 default => $::cassandra_service_name,
             }
 
+            $config_path = $::cassandra_config_path ? {
+                undef   => '/etc/cassandra/conf',
+                default => $::cassandra_config_path,
+            }
         }
         default: {
             fail("Unsupported osfamily: ${::osfamily}, operatingsystem: ${::operatingsystem}, module ${module_name} only supports osfamily Debian")

--- a/spec/classes/cassandra_config_spec.rb
+++ b/spec/classes/cassandra_config_spec.rb
@@ -1,9 +1,15 @@
 require 'spec_helper'
 
 describe 'cassandra::config' do
-
+  describe 'with supported os Debian' do
+    let :facts do
+      {
+        :osfamily => 'Debian'
+      }
+    end
   let(:params) do
     {
+      :config_path                => '/etc/cassandra',
       :max_heap_size              => '',
       :heap_newsize               => '',
       :jmx_port                   => 7199,
@@ -53,8 +59,8 @@ describe 'cassandra::config' do
   it 'does contain file /etc/cassandra/cassandra-env.sh' do
     should contain_file('/etc/cassandra/cassandra-env.sh').with({
       :ensure  => 'file',
-      :owner   => 'root',
-      :group   => 'root',
+      :owner   => 'cassandra',
+      :group   => 'cassandra',
       :mode    => '0644',
       :content => /MAX_HEAP_SIZE/,
     })
@@ -63,10 +69,87 @@ describe 'cassandra::config' do
   it 'does contain file /etc/cassandra/cassandra.yaml' do
     should contain_file('/etc/cassandra/cassandra.yaml').with({
       :ensure  => 'file',
-      :owner   => 'root',
-      :group   => 'root',
+      :owner   => 'cassandra',
+      :group   => 'cassandra',
       :mode    => '0644',
       :content => /cluster_name: 'Cassandra'/,
     })
   end
+  end
+
+  describe 'with supported os RedHat' do
+    let :facts do
+      {
+        :osfamily => 'Redhat'
+      }
+    end
+  let(:params) do
+    {
+      :config_path                => '/etc/cassandra/conf',
+      :max_heap_size              => '',
+      :heap_newsize               => '',
+      :jmx_port                   => 7199,
+      :additional_jvm_opts        => [],
+      :cluster_name               => 'Cassandra',
+      :listen_address             => '1.2.3.4',
+      :rpc_address                => '0.0.0.0',
+      :rpc_port                   => 9160,
+      :rpc_server_type            => 'hsha',
+      :storage_port               => 7000,
+      :partitioner                => 'org.apache.cassandra.dht.Murmur3Partitioner',
+      :data_file_directories      => ['/var/lib/cassandra/data'],
+      :commitlog_directory        => '/var/lib/cassandra/commitlog',
+      :saved_caches_directory     => '/var/lib/cassandra/saved_caches',
+      :initial_token              => '',
+      :seeds                      => ['1.2.3.4'],
+      :concurrent_reads           => 32,
+      :concurrent_writes          => 32,
+      :incremental_backups        => 'false',
+      :snapshot_before_compaction => 'false',
+      :auto_snapshot              => 'true',
+      :multithreaded_compaction   => 'false',
+      :endpoint_snitch            => 'SimpleSnitch',
+      :internode_compression      => 'all',
+      :disk_failure_policy        => 'stop',
+      :start_native_transport     => 'false',
+      :start_rpc                  => 'true',
+      :native_transport_port      => 9042,
+      :num_tokens                 => 256,
+    }
+  end
+  it 'does contain group cassandra' do
+    should contain_group('cassandra').with({
+      :ensure  => 'present',
+      :require => 'Class[Cassandra::Install]',
+    })
+  end
+
+  it 'does contain user cassandra' do
+    should contain_user('cassandra').with({
+      :ensure  => 'present',
+      :require => 'Group[cassandra]',
+    })
+  end
+
+  it 'does contain file /etc/cassandra/conf/cassandra-env.sh' do
+    should contain_file('/etc/cassandra/conf/cassandra-env.sh').with({
+      :ensure  => 'file',
+      :owner   => 'cassandra',
+      :group   => 'cassandra',
+      :mode    => '0644',
+      :content => /MAX_HEAP_SIZE/,
+    })
+  end
+
+  it 'does contain file /etc/cassandra/conf/cassandra.yaml' do
+    should contain_file('/etc/cassandra/conf/cassandra.yaml').with({
+      :ensure  => 'file',
+      :owner   => 'cassandra',
+      :group   => 'cassandra',
+      :mode    => '0644',
+      :content => /cluster_name: 'Cassandra'/,
+    })
+  end
+  end
+
 end


### PR DESCRIPTION
Tested your module on CentOS6 and found its partial RedHat support not working:
- Standard Config path for Redhat should be /etc/cassandra/conf/ not /etc/cassandra/ 
- File permissions fixed to cassandra:cassandra, otherwise data/log dir/files are wrong
- python-cql is called python26-cql on Redhat

You still have to take care of /etc/alternatives/cassandra pointing to the correct config path yourself by alternatives --install ....
