### PR TITLE
Added repo_key parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@ class cassandra(
     $config_path                = $cassandra::params::config_path,
     $include_repo               = $cassandra::params::include_repo,
     $repo_name                  = $cassandra::params::repo_name,
+    $repo_key                   = $cassandra::params::repo_key,
     $repo_baseurl               = $cassandra::params::repo_baseurl,
     $repo_gpgkey                = $cassandra::params::repo_gpgkey,
     $repo_repos                 = $cassandra::params::repo_repos,
@@ -123,6 +124,7 @@ class cassandra(
     if($include_repo) {
         class { 'cassandra::repo':
             repo_name => $repo_name,
+            repo_key  => $repo_key,
             baseurl   => $repo_baseurl,
             gpgkey    => $repo_gpgkey,
             repos     => $repo_repos,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,11 @@ class cassandra::params {
         default => $::cassandra_repo_name
     }
 
+    $repo_key = $::cassandra_repo_key ? {
+        undef   => 'B999A372',
+        default => $::cassandra_repo_key
+    }
+
     $repo_baseurl = $::cassandra_repo_baseurl ? {
         undef   => $::osfamily ? {
             'Debian' => 'http://debian.datastax.com/community',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -60,7 +60,7 @@ class cassandra::params {
     case $::osfamily {
         'Debian': {
             $package_name = $::cassandra_package_name ? {
-                undef   => 'dsc12',
+                undef   => 'dsc20',
                 default => $::cassandra_package_name,
             }
 
@@ -76,7 +76,7 @@ class cassandra::params {
         }
         'RedHat': {
             $package_name = $::cassandra_package_name ? {
-                undef   => 'dsc12',
+                undef   => 'dsc20',
                 default => $::cassandra_package_name,
             }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,5 +1,6 @@
 class cassandra::repo (
     $repo_name,
+    $repo_key,
     $baseurl,
     $gpgkey,
     $repos,
@@ -12,6 +13,7 @@ class cassandra::repo (
         'Debian': {
             class { 'cassandra::repo::debian':
                 repo_name  => $repo_name,
+                repo_key  => $repo_key,
                 location   => $baseurl,
                 repos      => $repos,
                 release    => $release,

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,5 +1,6 @@
 class cassandra::repo::debian(
     $repo_name,
+    $repo_key,
     $location,
     $repos,
     $release,
@@ -10,7 +11,7 @@ class cassandra::repo::debian(
         location          => $location,
         release           => $release,
         repos             => $repos,
-        key               => $repo_name,
+        key               => $repo_key,
         key_source        => $key_source,
         pin               => $pin,
         include_src       => false,


### PR DESCRIPTION
This solves problems with apt >= 1.5.0 as indicated in issue #15 (and #21)
Add a repo_key params which is, by default, datastax apt key. Do not affect Red Hat repo
